### PR TITLE
複数行一括変換のサポートなど

### DIFF
--- a/background.js
+++ b/background.js
@@ -27,8 +27,8 @@ function tweetTextFrom(line, prefix) {
     let twitterAccount = extractTwitterAccount(values[4].trim());
     let docURL = values[5].trim();
 
-    let presenter = (twitterAccount.length == 0) ? accountName : twitterAccount;
-    let nicknameText = (nickname.length == 0) ? "" : "（" + nickname + "）";
+    let presenter = twitterAccount || accountName;
+    let nicknameText = nickname ? "（" + nickname + "）" : "";
 
     return prefix + " " +
            presenter + nicknameText + "さんで" +

--- a/background.js
+++ b/background.js
@@ -1,3 +1,8 @@
+let HASHTAG = "#potatotips";
+let FIRST_PREFIX = "はじめは";
+let LAST_PREFIX = "最後は";
+let OTHER_PREFIX = "つぎは";
+
 function saveToClipboard(text) {
     console.log(text);
     var textArea = document.createElement("textarea")
@@ -12,42 +17,84 @@ function saveToClipboard(text) {
     document.body.removeChild(textArea);
 }
 
-function tweetTextFrom(text, isFirst) {
-    var splitted = text.split(" ");
-    var head = isFirst ? "はじめは" : "つぎは";
-    var lastIdx = splitted.length - 1;
- 
-    var presenter = splitted[0];
-    var nickname = splitted[1];
-    var twitterAccountIdx = splitted[lastIdx].match(/@/) ? lastIdx : lastIdx - 1;
-    var twitterAccount = splitted[twitterAccountIdx];
-    var platform = splitted[twitterAccountIdx - 1];
+function tweetTextFrom(line, prefix) {
+    let values = line;
 
-    var title = "";
-    for(let i = 2; i < twitterAccountIdx - 1; i++) {
-        title = title.concat(splitted[i], " ");
+    let accountName = values[0].trim();
+    let nickname = values[1].trim();
+    let title = values[2].trim();
+    let platform = values[3].trim();
+    let twitterAccount = extractTwitterAccount(values[4].trim());
+    let docURL = values[5].trim();
+
+    let presenter = (twitterAccount.length == 0) ? accountName : twitterAccount;
+    let nicknameText = (nickname.length == 0) ? "" : "（" + nickname + "）";
+
+    return prefix + " " +
+           presenter + nicknameText + "さんで" +
+           "「" + title + "」（" + platform + "） " +
+           " " + HASHTAG +
+           " " + docURL;
+}
+
+function tweetsTextFrom(text) {
+    let lines = textToLines(text)
+
+    if (lines.length == 1) {
+        return tweetTextFrom(lines[0], OTHER_PREFIX);
+    } else {
+        var result = "";
+        lines.forEach((line, index) => {
+            let prefix = prefixFor(index, lines.length);
+            result += tweetTextFrom(line, prefix) + "\n"
+        })
+        return result;
     }
-    title = title.slice(0, -1);
+}
 
-    return head + " " +
-           presenter + "（"　+ nickname + "）さんで" +
-           "「" + title + "」（" + platform + "） " +
-           twitterAccount + " #potatotips"; 
+function textToLines(text) {
+    let values = text.split("|");
+    values.shift();
+
+    var lines = [];
+    for (var i = 0; i < values.length; i += 7) {
+        let lineValues = values.slice(i, i + 7);
+        lines.push(lineValues);
+    }
+
+    return lines;
+}
+
+function prefixFor(index, count) {
+    if (count < 2) {
+        return OTHER_PREFIX;
+    }
+
+    switch (index) {
+    case 0:
+        return FIRST_PREFIX;
+    case count - 1:
+        return LAST_PREFIX;
+    default:
+        return OTHER_PREFIX;
+    }
+}
+
+function extractTwitterAccount(text) {
+    let result = text.match(/@[a-zA-Z0-9_]+/);
+
+    if (result) {
+      return result[0];
+    } else {
+      return text;
+    }
 }
 
 chrome.contextMenus.create({
-    "title": "クリップボードにコピー（はじめ）",
+    "title": "クリップボードにコピー",
     "type": "normal",
     "contexts": ["selection"],
     "onclick": function(info) {
-        saveToClipboard(tweetTextFrom(info.selectionText, true));
-    }
-});
-chrome.contextMenus.create({
-    "title": "クリップボードにコピー（つぎ）",
-    "type": "normal",
-    "contexts": ["selection"],
-    "onclick": function(info) {
-        saveToClipboard(tweetTextFrom(info.selectionText, false));
+        saveToClipboard(tweetsTextFrom(info.selectionText));
     }
 });


### PR DESCRIPTION
@laprasdrum Chrome Extensionの作成ありがとうございました！！

これから是非活用をさせてください。
また、とても感銘を受けて（今までChrome Extensionを作ったことがありませんでした）実運用に合わせて以下のカスタマイズをさせていただきました。

- 複数行を一括で変換する
    - ただ、これをサポートする場合、空白区切りでの判定のままだと厳しいため、Wikiのmarkdown形式（`|`区切り）のものを選択して利用させていただくことにしました

- presenterNameにはTwitterアカウントの記載があればそれを使い、なければアカウント名を使う
    - これまでもやりたかったけど手運用だと面倒でサボっていた部分でした

- Twitterアカウントがリンク付きの記述の場合はTwitterアカウントのみ抽出する
    - Markdown形式でコピーするようにした副作用の回避